### PR TITLE
PS-5231: Check for empty app prices after new App Store Connect API changes

### DIFF
--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -21,6 +21,15 @@ module Deliver
       # Need to get prices from the app's relationships
       # Prices from app's relationship doess not have price tier so need to fetch app price with price tier relationship
       app_prices = app.prices
+
+      # Monkey patch in the meantime Fastline provides a stable fix
+      # https://github.com/fastlane/fastlane/issues/21125
+      # https://github.com/fastlane/fastlane/issues/21125#issuecomment-1474628335
+      if app_prices.nil? 
+        UI.message("App has no prices yet... No changes required.") 
+        return 
+      end
+
       if app_prices.first
         app_price = Spaceship::ConnectAPI.get_app_price(app_price_id: app_prices.first.id, includes: "priceTier").first
         old_price = app_price.price_tier.id


### PR DESCRIPTION
This is a monkey patch related to [PS-5231](https://passionio.atlassian.net/browse/PS-5231)

Based on [this](https://github.com/fastlane/fastlane/issues/21125#issuecomment-1474628335) it should be a temporary for for the [main open fastlane issue](https://github.com/fastlane/fastlane/issues/21125), for which a fix has not been released yet.

This should fix the [CircleCI error message](https://app.circleci.com/pipelines/github/independenc3/elara/65404/workflows/eebe9158-2eeb-4ad7-85a8-09232b7c6ce1/jobs/101711) we're getting:

Main error:

```
/Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/deliver/lib/deliver/upload_price_tier.rb:24:in `upload': undefined method `first' for nil:NilClass (NoMethodError)

```

Stack

```
🔗  You can ⌘ + double-click on links to open them directly in your browser.
bundler: failed to load command: fastlane (/Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bin/fastlane)
Traceback (most recent call last):
	44: from /Users/distiller/.gem/ruby/2.7.4/bin/bundle:23:in `<main>'
	43: from /Users/distiller/.gem/ruby/2.7.4/bin/bundle:23:in `load'
	42: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/exe/bundle:37:in `<top (required)>'
	41: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	40: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/exe/bundle:49:in `block in <top (required)>'
	39: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli.rb:25:in `start'
	38: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	37: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli.rb:31:in `dispatch'
	36: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	35: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	34: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	33: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli.rb:477:in `exec'
	32: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli/exec.rb:23:in `run'
	31: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli/exec.rb:58:in `kernel_load'
	30: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli/exec.rb:58:in `load'
	29: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bin/fastlane:23:in `<top (required)>'
	28: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bin/fastlane:23:in `load'
	27: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/bin/fastlane:23:in `<top (required)>'
	26: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/cli_tools_distributor.rb:123:in `take_off'
	25: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/commands_generator.rb:43:in `start'
	24: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/commands_generator.rb:354:in `run'
	23: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
	22: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!'
	21: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
	20: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
	19: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
	18: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/commands_generator.rb:110:in `block (2 levels) in run'
	17: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/command_line_handler.rb:36:in `handle'
	16: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/lane_manager.rb:47:in `cruise_lane'
	15: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:45:in `execute'
	14: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:45:in `chdir'
	13: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
	12: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/lane.rb:33:in `call'
	11: from Fastfile:1273:in `block (2 levels) in parsing_binding'
	10: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/fast_file.rb:159:in `method_missing'
	 9: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name'
	 8: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:229:in `execute_action'
	 7: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:229:in `chdir'
	 6: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:255:in `block in execute_action'
	 5: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/actions/actions_helper.rb:69:in `execute_action'
	 4: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:263:in `block (2 levels) in execute_action'
	 3: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/actions/upload_to_app_store.rb:22:in `run'
	 2: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/deliver/lib/deliver/runner.rb:61:in `run'
	 1: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/deliver/lib/deliver/runner.rb:161:in `upload_metadata'
/Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/deliver/lib/deliver/upload_price_tier.rb:24:in `upload': undefined method `first' for nil:NilClass (NoMethodError)
	44: from /Users/distiller/.gem/ruby/2.7.4/bin/bundle:23:in `<main>'
	43: from /Users/distiller/.gem/ruby/2.7.4/bin/bundle:23:in `load'
	42: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/exe/bundle:37:in `<top (required)>'
	41: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	40: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/exe/bundle:49:in `block in <top (required)>'
	39: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli.rb:25:in `start'
	38: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	37: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli.rb:31:in `dispatch'
	36: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	35: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	34: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	33: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli.rb:477:in `exec'
	32: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli/exec.rb:23:in `run'
	31: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli/exec.rb:58:in `kernel_load'
	30: from /Users/distiller/.gem/ruby/2.7.4/gems/bundler-2.2.27/lib/bundler/cli/exec.rb:58:in `load'
	29: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bin/fastlane:23:in `<top (required)>'
	28: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bin/fastlane:23:in `load'
	27: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/bin/fastlane:23:in `<top (required)>'
	26: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/cli_tools_distributor.rb:123:in `take_off'
	25: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/commands_generator.rb:43:in `start'
	24: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/commands_generator.rb:354:in `run'
	23: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
	22: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!'
	21: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
	20: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
	19: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
	18: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/commands_generator.rb:110:in `block (2 levels) in run'
	17: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/command_line_handler.rb:36:in `handle'
	16: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/lane_manager.rb:47:in `cruise_lane'
	15: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:45:in `execute'
	14: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:45:in `chdir'
	13: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
	12: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/lane.rb:33:in `call'
	11: from Fastfile:1273:in `block (2 levels) in parsing_binding'
	10: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/fast_file.rb:159:in `method_missing'
	 9: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name'
	 8: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:229:in `execute_action'
	 7: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:229:in `chdir'
	 6: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:255:in `block in execute_action'
	 5: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/actions/actions_helper.rb:69:in `execute_action'
	 4: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/runner.rb:263:in `block (2 levels) in execute_action'
	 3: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/fastlane/lib/fastlane/actions/upload_to_app_store.rb:22:in `run'
	 2: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/deliver/lib/deliver/runner.rb:61:in `run'
	 1: from /Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/deliver/lib/deliver/runner.rb:161:in `upload_metadata'
/Users/distiller/project/app/ios/vendor/bundle/ruby/2.7.0/bundler/gems/fastlane-28f123c4dbb7/deliver/lib/deliver/upload_price_tier.rb:24:in `upload': \e[31m[!] undefined method `first' for nil:NilClass\e[0m (NoMethodError)

Exited with code exit status 1
CircleCI received exit code 1
```

[PS-5231]: https://passionio.atlassian.net/browse/PS-5231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ